### PR TITLE
Fix GitHub workflow not closing Minecraft issues

### DIFF
--- a/.github/workflows/minecraft-crash.yml
+++ b/.github/workflows/minecraft-crash.yml
@@ -129,10 +129,10 @@ jobs:
               })
 
               // We will close any Minecraft-related issue automatically.
-              github.rest.issues.update({
+              github.issues.update({
                 owner: owner,
                 repo: repo,
-                issue_number: inputs.issueNumber,
+                issue_number: issueNumber,
                 state: 'closed'
               })
             }


### PR DESCRIPTION
The workflow currently still uses actions/github-script version 4, so the examples shown in the [README](https://github.com/actions/github-script#breaking-changes-in-v5) using `github.rest.*` do not work yet.

See also test runs which show the workflow failures:
- https://github.com/Marcono1234/openjdk/runs/3900220130?check_suite_focus=true
- https://github.com/Marcono1234/openjdk/runs/3900260000?check_suite_focus=true
