### PR TITLE
Detect Minecraft Forge as modded in GitHub workflow

### DIFF
--- a/.github/workflows/minecraft-crash.yml
+++ b/.github/workflows/minecraft-crash.yml
@@ -21,6 +21,10 @@ jobs:
               'net.fabricmc.loader.impl.launch.knot.KnotClient', // new class name
               '--version fabric-loader-',
               '--tweakClass optifine.OptiFineTweaker',
+              // Minecraft Forge
+              '--launchTarget forgeclient',
+              '--launchTarget fmlserver',
+              '--fml.forgeVersion',
             ]
 
             const axios = require('axios')


### PR DESCRIPTION
It looks like recently multiple GitHub issues were created for crashes of modded Minecraft using Minecraft Forge, however the GitHub workflow previously did not detect it as modded.

These changes should fix that.