### PR TITLE
Update GitHub workflow actions

### DIFF
--- a/.github/workflows/format-crash-report-in-issue-body.yml
+++ b/.github/workflows/format-crash-report-in-issue-body.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Format crash report
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         with:
           script: |
             const issueNumber = context.issue.number

--- a/.github/workflows/minecraft-crash-reported-upstream-check.yml
+++ b/.github/workflows/minecraft-crash-reported-upstream-check.yml
@@ -11,7 +11,7 @@ jobs:
         # Ignore pull request comments, see
         # https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#issue_comment
         if: ${{ !github.event.issue.pull_request }}
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         with:
           script: |
             // See documentation for payload properties

--- a/.github/workflows/minecraft-crash.yml
+++ b/.github/workflows/minecraft-crash.yml
@@ -7,12 +7,12 @@ jobs:
   check-minecraft-crash:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
       - run: npm install axios
       - name: Check Minecraft crash
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         with:
           script: |
             // Strings which indicate that Minecraft is modded


### PR DESCRIPTION
The currently used action versions were causing warnings:
![Warning screenshot](https://user-images.githubusercontent.com/11685886/229604597-5b3f30fe-f654-4f19-9910-a3bad2b468ba.png)

Have tested the workflows on my fork shortly and they still seem to work as expected.