### PR TITLE
Improve GitHub workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/format-crash-report-in-issue-body.yml
+++ b/.github/workflows/format-crash-report-in-issue-body.yml
@@ -26,7 +26,7 @@ jobs:
 
             // Check if issue contains code block
             if (issueBody.includes('```')) {
-              console.log('Issue body seems to contain code block; skipping formatting')
+              core.info('Issue body seems to contain code block; skipping formatting')
               return
             }
 
@@ -35,9 +35,9 @@ jobs:
             const newIssueBody = issueBody.replace(crashReportPattern, '\n```\n$&\n```\n')
 
             if (newIssueBody === issueBody) {
-              console.log('Did not find crash report in issue body')
+              core.info('Did not find crash report in issue body')
             } else {
-              console.log('Found crash report in issue body, formatting it')
+              core.notice('Found crash report in issue body, formatting it')
               github.rest.issues.update({
                 owner: owner,
                 repo: repo,

--- a/.github/workflows/format-crash-report-in-issue-body.yml
+++ b/.github/workflows/format-crash-report-in-issue-body.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Format crash report
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const issueNumber = context.issue.number

--- a/.github/workflows/format-crash-report-in-issue-body.yml
+++ b/.github/workflows/format-crash-report-in-issue-body.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  issues: write
+
 jobs:
   format-crash-report:
     runs-on: ubuntu-latest

--- a/.github/workflows/minecraft-crash-reported-upstream-check.yml
+++ b/.github/workflows/minecraft-crash-reported-upstream-check.yml
@@ -3,6 +3,9 @@ on:
   issue_comment:
     types: [created, edited]
 
+permissions:
+  issues: write
+
 jobs:
   check-reported-upstream:
     runs-on: ubuntu-latest

--- a/.github/workflows/minecraft-crash-reported-upstream-check.yml
+++ b/.github/workflows/minecraft-crash-reported-upstream-check.yml
@@ -24,7 +24,7 @@ jobs:
             const sender = context.payload.sender.login
 
             if (issue.user.login !== sender) {
-              console.log('Ignoring comment by user other than author')
+              core.info('Ignoring comment by user other than author')
               return
             }
 
@@ -32,11 +32,11 @@ jobs:
             const issueLabels = issue.labels.map(label => label.name)
 
             if (issueLabels.includes(reportedUpstreamLabel)) {
-              console.log('Ignoring issue because it already has upstream label')
+              core.info('Ignoring issue because it already has upstream label')
               return
             }
             if (!issueLabels.includes('Minecraft')) {
-              console.log('Ignoring issue because it is not labeled as Minecraft')
+              core.info('Ignoring issue because it is not labeled as Minecraft')
               return
             }
 
@@ -47,10 +47,10 @@ jobs:
             const matchedMojiraIssueKey = /(?<!\w)MC-\d{6,}(?!\w)(?<!MC-123456)/i.exec(commentBody)
 
             if (matchedMojiraIssueKey === null) {
-              console.log('Did not find Mojira issue key in comment')
+              core.info('Did not find Mojira issue key in comment')
             }
             else {
-              console.log(`Found Mojira issue key ${matchedMojiraIssueKey[0]}, adding label`)
+              core.notice(`Found Mojira issue key ${matchedMojiraIssueKey[0]}, adding label`)
 
               const owner = context.repo.owner
               const repo = context.repo.repo

--- a/.github/workflows/minecraft-crash-reported-upstream-check.yml
+++ b/.github/workflows/minecraft-crash-reported-upstream-check.yml
@@ -11,7 +11,7 @@ jobs:
         # Ignore pull request comments, see
         # https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#issue_comment
         if: ${{ !github.event.issue.pull_request }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             // See documentation for payload properties

--- a/.github/workflows/minecraft-crash.yml
+++ b/.github/workflows/minecraft-crash.yml
@@ -7,12 +7,12 @@ jobs:
   check-minecraft-crash:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - run: npm install axios
       - name: Check Minecraft crash
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             // Strings which indicate that Minecraft is modded

--- a/.github/workflows/minecraft-crash.yml
+++ b/.github/workflows/minecraft-crash.yml
@@ -10,10 +10,6 @@ jobs:
   check-minecraft-crash:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-      - run: npm install axios
       - name: Check Minecraft crash
         uses: actions/github-script@v7
         with:
@@ -30,16 +26,12 @@ jobs:
               '--fml.forgeVersion',
             ]
 
-            const axios = require('axios')
-
             async function httpGet(url) {
-              const result = await axios.get(url, {
-                responseType: 'text'
-              })
-              const status = result.status
-              const data = result.data
+              const response = await fetch(url)
+              const status = response.status
+              const data = await response.text()
               if (status < 200 || status >= 300) {
-                throw new Error(`GET request to ${url} failed with ${status} '${result.statusText}': ${data}`)
+                throw new Error(`GET request to ${url} failed with ${status} '${response.statusText}': ${data}`)
               }
               return data
             }

--- a/.github/workflows/minecraft-crash.yml
+++ b/.github/workflows/minecraft-crash.yml
@@ -53,26 +53,26 @@ jobs:
 
             const foundModdedStrings = moddedStrings.filter(s => issueBody.includes(s))
             if (foundModdedStrings.length === 0) {
-              console.log('Did not find modded string in issue body, searching attachments')
+              core.info('Did not find modded string in issue body, searching attachments')
               // Try searching in attachments
               // There is currently no API so try to find URL then get attachment content, see https://github.community/t/get-files-attached-in-issue/117443
               const attachmentPattern = new RegExp(`https://github\\.com/${owner}/${repo}/files/\\d+/[a-zA-Z0-9_\\-.]+`, 'g')
               const attachmentUrls = Array.from(issueBody.matchAll(attachmentPattern), m => m[0])
-              console.log('Found attachment URLs', attachmentUrls)
+              core.info(`Found attachment URLs: ${attachmentUrls}`)
               for (const url of attachmentUrls) {
                 let attachment = undefined
                 try {
                   attachment = await httpGet(url)
                 } catch (e) {
                   // Only log message because complete error is rather verbose
-                  console.log('Failed getting attachment for ' + url, e.message)
+                  core.warning(`Failed getting attachment for ${url}: ${e.message}`)
                   continue
                 }
 
                 if (!isMinecraftIssue) {
                   isMinecraftIssue = minecraftRegex.test(attachment)
                   if (isMinecraftIssue) {
-                    console.log('Found Minecraft string in attachment')
+                    core.info('Found Minecraft string in attachment')
                   }
                 }
 
@@ -87,14 +87,15 @@ jobs:
             let isCrashFromModdedMinecraft = foundModdedStrings.length > 0
 
             if (isCrashFromModdedMinecraft) {
-              console.log('Found modded strings', foundModdedStrings)
+              core.notice(`Found modded strings: ${foundModdedStrings}`)
             } else {
-              console.log('Did not find modded strings')
+              core.info('Did not find modded strings')
             }
             isMinecraftIssue = isMinecraftIssue || isCrashFromModdedMinecraft
-            console.log('Is Minecraft issue: ' + isMinecraftIssue)
 
             if (isMinecraftIssue) {
+              core.notice('Detected issue to be about Minecraft')
+
               let commentBody
               if (isCrashFromModdedMinecraft) {
                 // Don't tell user to report modded crashes on Mojang's bug tracker; they will most likely be considered Invalid

--- a/.github/workflows/minecraft-crash.yml
+++ b/.github/workflows/minecraft-crash.yml
@@ -3,6 +3,9 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  issues: write
+
 jobs:
   check-minecraft-crash:
     runs-on: ubuntu-latest


### PR DESCRIPTION
See commit messages for details.

This should hopefully also fix the recent failures for check-minecraft-crash, such as https://github.com/microsoft/openjdk/actions/runs/7862088834/job/21451176993.
Possibly the GitHub token default permissions were made more strict for the microsoft organization or this repository, which caused the errors (?). Now the workflows explicitly specify the required permissions, so it should work again.

This pull request also enables Dependabot for the GitHub actions, but only with a monthly interval. And because the workflows currently only refer to major versions of the actions, this will probably only create a pull request if there is a new major version available (and not for every patch version).
However, because these workflows are not run on pull requests, the release notes for upgraded actions have to be checked for any breaking changes, and after merging the Dependabot pull request might be good to have a close look at workflow runs in the next days to verify that nothing broke.

Please let me know if I should omit enabling Dependabot.
