### PR TITLE
Add JDK25 to source code list

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ Visit the [Releases](https://github.com/microsoft/openjdk/releases) page for the
 The source code of our builds are hosted on the following repositories:
 
 1. [microsoft/openjdk-jdk11u](https://github.com/microsoft/openjdk-jdk11u)
-2. [microsoft/openjdk-jdk17u](https://github.com/microsoft/openjdk-jdk17u)
-3. [microsoft/openjdk-jdk21u](https://github.com/microsoft/openjdk-jdk21u) 
+1. [microsoft/openjdk-jdk17u](https://github.com/microsoft/openjdk-jdk17u)
+1. [microsoft/openjdk-jdk21u](https://github.com/microsoft/openjdk-jdk21u)
+1. [microsoft/openjdk-jdk25u](https://github.com/microsoft/openjdk-jdk25u) 
 
 The source code of our container images are hosted on the following repository:
 


### PR DESCRIPTION
Add our microsoft/openjdk-jdk25u repo to the list of source code repositories. Changed the number to a more simple-streamlined method of listing. 